### PR TITLE
Fix iterating using only a timestamp column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix iterating using only a timestamp column
+
 - Add the ability to skip implicitly appending a primary key to the list of sorting columns.
 
     It may be useful to disable it for the table with a UUID primary key or when the sorting

--- a/lib/activerecord_cursor_paginate/cursor.rb
+++ b/lib/activerecord_cursor_paginate/cursor.rb
@@ -48,8 +48,8 @@ module ActiveRecordCursorPaginate
     attr_reader :columns, :values
 
     def initialize(columns:, values:)
-      @columns = Array(columns)
-      @values = Array(values)
+      @columns = Array.wrap(columns)
+      @values = Array.wrap(values)
 
       raise ArgumentError, "Cursor values can not be nil" if @values.any?(nil)
       raise ArgumentError, ":columns and :values have different sizes" if @columns.size != @values.size

--- a/test/paginator_test.rb
+++ b/test/paginator_test.rb
@@ -184,6 +184,15 @@ class PaginatorTest < Minitest::Test
     assert_equal([7, 4, 10], page2.records.pluck(:id))
   end
 
+  def test_paginating_over_time_column_without_primary_key
+    p = User.cursor_paginate(limit: 3, order: { created_at: :asc }, append_primary_key: false)
+    page1 = p.fetch
+    assert_equal([5, 3, 8], page1.records.pluck(:id))
+
+    page2 = p.fetch
+    assert_equal([7, 4, 10], page2.records.pluck(:id))
+  end
+
   def test_paginating_over_all_pages
     p = User.cursor_paginate(limit: 2)
 


### PR DESCRIPTION
When the cursor is created with only one time column, decoding it would crash, reporting that the columns and values have different sizes.

This is because `Array(values)` attempts to call `#to_ary` and `#to_a` on its arguments before manually wrapping it in an array. This means that `Time#to_a` is called, which returns an array of 10 elements.

The remedy is to do that manual wrapping ourselves, so that we can ensure that the values are always wrapped in an array, and then call `flatten` so that if an array was passed in, it is unwrapped back into a single level array.

Fixes #4 