### PR TITLE
Fix `next_cursor`/`previous_cursor` for empty pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Style/SymbolArray:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Layout/EmptyLinesAroundAccessModifier:
   EnforcedStyle: only_before
 
@@ -52,4 +55,7 @@ Minitest/MultipleAssertions:
   Enabled: false
 
 Minitest/EmptyLineBeforeAssertionMethods:
+  Enabled: false
+
+Minitest/AssertEmptyLiteral:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Fix `next_cursor`/`previous_cursor` for empty pages
 - Fix iterating using only a timestamp column
 
 - Add the ability to skip implicitly appending a primary key to the list of sorting columns.

--- a/lib/activerecord_cursor_paginate/page.rb
+++ b/lib/activerecord_cursor_paginate/page.rb
@@ -78,8 +78,10 @@ module ActiveRecordCursorPaginate
 
     private
       def cursor_for_record(record)
-        cursor = Cursor.from_record(record, columns: @order_columns)
-        cursor.encode
+        if record
+          cursor = Cursor.from_record(record, columns: @order_columns)
+          cursor.encode
+        end
       end
   end
 end

--- a/test/paginator_test.rb
+++ b/test/paginator_test.rb
@@ -275,4 +275,17 @@ class PaginatorTest < Minitest::Test
     assert page2.has_next?
     assert page2.has_previous?
   end
+
+  def test_empty_page
+    p = User.where("created_at > ?", Time.current).cursor_paginate
+    page = p.fetch
+
+    assert_equal([], page.records)
+    assert_equal(0, page.count)
+    assert_nil page.next_cursor
+    assert_nil page.previous_cursor
+    assert_not page.has_previous?
+    assert_not page.has_next?
+    assert_empty page.cursors
+  end
 end


### PR DESCRIPTION
This addresses an issue that getting `next_cursor` when `has_next?` is `false` that would raise a `NoMethodError`

```
NoMethodError: undefined method `[]' for nil
    lib/activerecord_cursor_paginate/cursor.rb:12:in `block in from_record'
    lib/activerecord_cursor_paginate/cursor.rb:12:in `map'
    lib/activerecord_cursor_paginate/cursor.rb:12:in `from_record'
    lib/activerecord_cursor_paginate/page.rb:81:in `cursor_for_record'
    lib/activerecord_cursor_paginate/page.rb:38:in `next_cursor'
    test/paginator_test.rb:285:in `test_empty_page'
```