### PR TITLE
Fix `Paginator#limit` to return default page size by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix `Paginator#limit` to return default page size by default
+
 ## 0.4.0 (2025-03-10)
 
 - Add ability to paginate backward from the end of the collection

--- a/lib/activerecord_cursor_paginate/paginator.rb
+++ b/lib/activerecord_cursor_paginate/paginator.rb
@@ -104,7 +104,7 @@ module ActiveRecordCursorPaginate
       config = ActiveRecordCursorPaginate.config
       @page_size = value || config.default_page_size
       @page_size = [@page_size, config.max_page_size].min if config.max_page_size
-      @limit = value
+      @limit = @page_size
     end
 
     def order=(value)

--- a/test/paginator_test.rb
+++ b/test/paginator_test.rb
@@ -93,6 +93,7 @@ class PaginatorTest < Minitest::Test
   def test_uses_default_limit
     ActiveRecordCursorPaginate.config.stub(:default_page_size, 4) do
       p = User.cursor_paginate
+      assert_equal 4, p.limit
       users = p.fetch.records
       assert_equal([1, 2, 3, 4], users.pluck(:id))
     end
@@ -100,6 +101,7 @@ class PaginatorTest < Minitest::Test
 
   def test_custom_limit
     p = User.cursor_paginate(limit: 3)
+    assert_equal 3, p.limit
     users = p.fetch.records
     assert_equal([1, 2, 3], users.pluck(:id))
   end


### PR DESCRIPTION
Fixes #19.